### PR TITLE
Don't allow 100 CONTINUE on 1.0 streams

### DIFF
--- a/http/h1_stream.lua
+++ b/http/h1_stream.lua
@@ -449,6 +449,12 @@ function stream_methods:write_headers(headers, end_stream, timeout)
 		if self.state == "idle" then
 			error("cannot write headers when stream is idle")
 		end
+		status_code = headers:get(":status")
+		-- RFC 2616 Section 8.2.3:
+		-- An origin server ... MUST NOT send a 100 (Continue) response if such a request comes from an HTTP/1.0 (or earlier) client
+		if status_code == "100" and self.peer_version < 1.1 then
+			return error("Status code 100 (continue) MUST NOT be sent in reply to a request from a HTTP/1.0 client")
+		end
 		-- Make sure we're at the front of the pipeline
 		if self.connection.pipeline:peek() ~= self then
 			if not self.pipeline_cond:wait(deadline and (deadline-monotime)) then
@@ -456,7 +462,6 @@ function stream_methods:write_headers(headers, end_stream, timeout)
 			end
 			assert(self.connection.pipeline:peek() == self)
 		end
-		status_code = headers:get(":status")
 		if status_code then
 			-- Should send status line
 			local reason_phrase = reason_phrases[status_code]


### PR DESCRIPTION
> An origin server ... MUST NOT send a 100 (Continue) response if such a request comes from an HTTP/1.0 (or earlier) client

Thanks @kogir https://news.ycombinator.com/item?id=12484978
