### PR TITLE
tostring header value in socket compat

### DIFF
--- a/http/compat/socket.lua
+++ b/http/compat/socket.lua
@@ -138,7 +138,7 @@ function M.request(reqt, b)
 			if name == "host" then
 				req.headers:upsert(":authority", field)
 			else
-				req.headers:append(name:lower(), field)
+				req.headers:append(name:lower(), tostring(field))
 			end
 		end
 	end


### PR DESCRIPTION
in luasocket you can pass a numeric value to a header and it sends it correctly as a string. With your compat library it will raise an error:

```
moon: ...leafo/.luarocks/share/lua/5.1/http/h1_connection.lua:399: field value invalid
stack traceback:
	[C]: in function 'assert'
	...leafo/.luarocks/share/lua/5.1/http/h1_connection.lua:399: in function 'write_header'
	...ome/leafo/.luarocks/share/lua/5.1/http/h1_stream.lua:689: in function 'write_headers'
```

I don't know where the appropriate place to fix this is, do you want to have the core library cast to string, or just have this fix as part of the compatibility layer?

In any case, I made a simple fix in the compatibility layer, but feel free to do your own solution.