### PR TITLE
Allow selecting local bind address for clients

### DIFF
--- a/http/client.lua
+++ b/http/client.lua
@@ -89,6 +89,7 @@ local function connect(options, timeout)
 		host = options.host;
 		port = options.port;
 		path = options.path;
+		bind = options.bind;
 		sendname = false;
 		v6only = options.v6only;
 		nodelay = true;

--- a/http/client.lua
+++ b/http/client.lua
@@ -84,12 +84,30 @@ local function negotiate(s, options, timeout)
 end
 
 local function connect(options, timeout)
+	local bind = options.bind
+	if bind ~= nil then
+		assert(type(bind) == "string")
+		local bind_address, bind_port = bind:match("^(.-):(%d+)$")
+		if bind_address then
+			bind_port = tonumber(bind_port, 10)
+		else
+			bind_address = bind
+		end
+		local ipv6 = bind_address:match("^%[([:%x]+)%]$")
+		if ipv6 then
+			bind_address = ipv6
+		end
+		bind = {
+			address = bind_address;
+			port = bind_port;
+		}
+	end
 	local s, err, errno = ca.fileresult(cs.connect {
 		family = options.family;
 		host = options.host;
 		port = options.port;
 		path = options.path;
-		bind = options.bind;
+		bind = bind;
 		sendname = false;
 		v6only = options.v6only;
 		nodelay = true;

--- a/http/request.lua
+++ b/http/request.lua
@@ -107,6 +107,7 @@ function request_methods:clone()
 	return setmetatable({
 		host = self.host;
 		port = self.port;
+		bind = self.bind;
 		tls = self.tls;
 		ctx = self.ctx;
 		sendname = self.sendname;
@@ -467,6 +468,7 @@ function request_methods:go(timeout)
 		connection, err, errno = client.connect({
 			host = host;
 			port = port;
+			bind = self.bind;
 			tls = tls;
 			ctx = self.ctx;
 			sendname = self.sendname;


### PR DESCRIPTION
This implementation just passes 'bind' field directly through to cqueues.

cqueues accepts either an address as a string (e.g. `.bind = "127.0.0.2"`) or a table with fields `.address` and `.port` (as well as a few aliases).
The latter table form would cause issues with connection pooling, and I have questions about what `req:clone()` would do (deep copy?).
To avoid such tricky questions, I'm restricting `bind` to be a string of *address:port*. where for an ipv6 address you can write `[::]:port`