### PR TITLE
http/client: Don't verify IP

### DIFF
--- a/http/client.lua
+++ b/http/client.lua
@@ -44,13 +44,9 @@ local function negotiate(s, options, timeout)
 		if version == 2 then
 			ssl:setOptions(openssl_ctx.OP_NO_TLSv1 + openssl_ctx.OP_NO_TLSv1_1)
 		end
-		if options.host and http_tls.has_hostname_validation then
+		if options.host and http_tls.has_hostname_validation and not ip then
 			local params = openssl_verify_param.new()
-			if ip then
-				params:setIP(options.host)
-			else
-				params:setHost(options.host)
-			end
+			params:setHost(options.host)
 			-- Allow user defined params to override
 			local old = ssl:getParam()
 			old:inherit(params)


### PR DESCRIPTION
OpenSSL's API does not allow for removing an IP verification once set (see https://github.com/openssl/openssl/issues/2673)

This means in turn that (without this PR) you can't use an IP as the connect address if you don't want to verify that it presents a certificate for it (e.g. if you did the dns lookup out of band).

```lua
local http_request = require "http.request"
local http_tls = require "http.tls"
local openssl_verify_param = require "openssl.x509.verify_param"

local r = http_request.new_from_uri("https://google.com")
r.host = "216.58.199.78" -- manually looked up IP for google
r.sendname = "google.com"
r.ctx = http_tls.new_client_context()
local params = openssl_verify_param.new()
params:setHost("google.com")
r.ctx:setParam(params)

print(r:go()) -- nil	starttls: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed:IP address mismatch	-1935895353
```