### PR TITLE
Add server:connections()

### DIFF
--- a/doc/modules/http.server.md
+++ b/doc/modules/http.server.md
@@ -98,6 +98,11 @@ This method is used for integrating with other main loops, and should be used in
 Returns `true` if the master socket and all client connection have been closed, `false` otherwise.
 
 
+### `server:connections()` <!-- --> {#http.server:connections}
+
+Returns the number of clients currently connected to this server.
+
+
 ### `server:step(timeout)` <!-- --> {#http.server:step}
 
 Step once through server's main loop: any waiting clients will be `accept()`-ed, any pending streams will start getting processed, and each `onstream` handler will get be run at most once. This method will block for *up to* `timeout` seconds. On error, returns `nil`, an error message and an error number.

--- a/http/server.lua
+++ b/http/server.lua
@@ -472,6 +472,10 @@ function server_methods:loop(...)
 	return self.cq:loop(...)
 end
 
+function server_methods:connections()
+	return self.n_connections
+end
+
 function server_methods:add_socket(socket)
 	self.n_connections = self.n_connections + 1
 	self.cq:wrap(handle_socket, self, socket)

--- a/spec/server_spec.lua
+++ b/spec/server_spec.lua
@@ -77,12 +77,14 @@ describe("http.server module", function()
 			options.port = 0
 		end
 		local onstream = spy.new(function(s, stream)
+			assert.is_equal(1, s:connections())
 			stream:get_headers()
 			stream:shutdown()
 			s:close()
 		end)
 		options.onstream = onstream
 		local s = assert(http_server.listen(options))
+		assert.is_equal(0, s:connections())
 		assert(s:listen())
 		cq:wrap(function()
 			assert_loop(s)
@@ -125,6 +127,7 @@ describe("http.server module", function()
 		assert_loop(cq, TEST_TIMEOUT)
 		assert.truthy(cq:empty())
 		assert.spy(onstream).was.called()
+		assert.is_equal(0, s:connections())
 	end
 	it("works with plain http 1.1 using IP", function()
 		simple_test(cs.AF_INET, false, 1.1)


### PR DESCRIPTION
Adds :connections() method to http.server objects, so that external code can see how many client connections are actively being handled.

A project needed this for statistics and load balancing.