### PR TITLE
try using native bitwise operations without checking lua version

### DIFF
--- a/http/bit.lua
+++ b/http/bit.lua
@@ -7,24 +7,17 @@ The bit operations are only done
 This means we can ignore the differences between bit libraries.
 ]]
 
--- Lua 5.1's load function doesn't support reading strings, only
--- functions.
-local function string_loader(str)
-	local sent = false
-	return function()
-		if sent then return nil end
-		sent = false
-		return str
-	end
-end
+-- Lua 5.1 uses loadstring for load with a string, Lua 5.2+ just
+-- uses load.
+local load = loadstring or load
 
 -- Lua 5.3+ has built-in bit operators, wrap them in a function.
 local info = debug.getinfo(1, "Sl")
-local has_bitwise, bitwise = pcall(load(string_loader(("\n"):rep(info.currentline+1)..[[return {
+local has_bitwise, bitwise = pcall(load(("\n"):rep(info.currentline+1)..[[return {
 	band = function(a, b) return a & b end;
 	bor = function(a, b) return a | b end;
 	bxor = function(a, b) return a ~ b end;
-}]]), info.source))
+}]], info.source))
 if has_bitwise then return bitwise end
 
 -- The "bit" library that comes with luajit

--- a/http/bit.lua
+++ b/http/bit.lua
@@ -7,16 +7,25 @@ The bit operations are only done
 This means we can ignore the differences between bit libraries.
 ]]
 
--- Lua 5.3 has built-in bit operators, wrap them in a function.
-if _VERSION == "Lua 5.3" then
-	-- Use debug.getinfo to get correct file+line numbers for loaded snippet
-	local info = debug.getinfo(1, "Sl")
-	return assert(load(("\n"):rep(info.currentline+1)..[[return {
-		band = function(a, b) return a & b end;
-		bor = function(a, b) return a | b end;
-		bxor = function(a, b) return a ~ b end;
-	}]], info.source))()
+-- Lua 5.1's load function doesn't support reading strings, only
+-- functions.
+local function string_loader(str)
+	local sent = false
+	return function()
+		if sent then return nil end
+		sent = false
+		return str
+	end
 end
+
+-- Lua 5.3+ has built-in bit operators, wrap them in a function.
+local info = debug.getinfo(1, "Sl")
+local has_bitwise, bitwise = pcall(load(string_loader(("\n"):rep(info.currentline+1)..[[return {
+	band = function(a, b) return a & b end;
+	bor = function(a, b) return a | b end;
+	bxor = function(a, b) return a ~ b end;
+}]]), info.source))
+if has_bitwise then return bitwise end
 
 -- The "bit" library that comes with luajit
 -- also available for lua 5.1 as "luabitop": http://bitop.luajit.org/


### PR DESCRIPTION
This is an alternative to #174 

Rather than relying on `_VERSION == "Lua 5.3"`, this just tries loading the Lua 5.3+ wrapper table no matter what. Assuming future versions of Lua keep bitwise ops, this should work on future versions of Lua.

Plus it should be compatible with forks/renames/etc.