### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+arch:
+ - amd64
+ - ppc64le
+ 
 sudo: false
 
 env:
@@ -24,6 +28,26 @@ env:
     - LUA="luajit 2.1"
     - LUA="luajit 2.1" ZLIB=lzlib
     - LUA="luajit 2.1" ZLIB=lua-zlib
+jobs:
+    exclude:
+        - arch: ppc64le
+          env: LUA="luajit @"
+        - arch: ppc64le
+          env: LUA="luajit @"   ZLIB=lzlib    
+        - arch: ppc64le
+          env: LUA="luajit @"   ZLIB=lua-zlib
+        - arch: ppc64le
+          env: LUA="luajit 2.0"       
+        - arch: ppc64le
+          env: LUA="luajit 2.0" ZLIB=lzlib       
+        - arch: ppc64le
+          env: LUA="luajit 2.0" ZLIB=lua-zlib
+        - arch: ppc64le
+          env: LUA="luajit 2.1"
+        - arch: ppc64le
+          env: LUA="luajit 2.1" ZLIB=lzlib
+        - arch: ppc64le
+          env: LUA="luajit 2.1" ZLIB=lua-zlib    
 
 branches:
   only:


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch and exclude luajit @, luajit 2.0 and luajit 2.1 since its not supporting ppc64le Arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.org/github/zazzel/lua-http/builds/748072595
Please have a look.

Thanks