### PR TITLE
http/bit: refactor to try bitwise operators in 5.3+

### DIFF
--- a/http/bit.lua
+++ b/http/bit.lua
@@ -7,15 +7,19 @@ The bit operations are only done
 This means we can ignore the differences between bit libraries.
 ]]
 
--- Lua 5.3 has built-in bit operators, wrap them in a function.
-if _VERSION == "Lua 5.3" then
+-- Lua 5.1 didn't have `load` or bitwise operators, just let it fall through.
+if _VERSION ~= "Lua 5.1" then
+    -- Lua 5.3+ has built-in bit operators, wrap them in a function.
 	-- Use debug.getinfo to get correct file+line numbers for loaded snippet
 	local info = debug.getinfo(1, "Sl")
-	return assert(load(("\n"):rep(info.currentline+1)..[[return {
+	local has_bitwise, bitwise = pcall(load(("\n"):rep(info.currentline+1)..[[return {
 		band = function(a, b) return a & b end;
 		bor = function(a, b) return a | b end;
 		bxor = function(a, b) return a ~ b end;
-	}]], info.source))()
+	}]], info.source))
+	if has_bitwise then
+		return bitwise
+	end
 end
 
 -- The "bit" library that comes with luajit


### PR DESCRIPTION
Rather than only attempt in Lua 5.3.
This improves Lua 5.4 compatibility.

Supercedes #177