### PR TITLE
Add custom headers into the websocket client connection.

### DIFF
--- a/doc/modules/http.websocket.md
+++ b/doc/modules/http.websocket.md
@@ -1,10 +1,11 @@
 ## http.websocket
 
-### `new_from_uri(uri, protocols)` <!-- --> {#http.websocket.new_from_uri}
+### `new_from_uri(uri, protocols, headers)` <!-- --> {#http.websocket.new_from_uri}
 
 Creates a new `http.websocket` object of type `"client"` from the given URI.
 
   - `protocols` (optional) should be a lua table containing a sequence of protocols to send to the server
+  - [`headers`](#http.headers) (optional) should be customs headers if needed.
 
 
 ### `new_from_stream(stream, headers)` <!-- --> {#http.websocket.new_from_stream}

--- a/http/websocket.lua
+++ b/http/websocket.lua
@@ -553,8 +553,10 @@ local function new_from_uri(uri, protocols, headers)
 	self.key = new_key()
 	self.request.headers:append("sec-websocket-key", self.key, true)
 	self.request.headers:append("sec-websocket-version", "13")
-	for name, value, _ in headers:each() do
-		self.request.headers:append(name, value)
+	if(headers)then
+		for name, value, _ in headers:each() do
+			self.request.headers:append(name, value)
+		end
 	end
 	if protocols then
 		--[[ The request MAY include a header field with the name

--- a/http/websocket.lua
+++ b/http/websocket.lua
@@ -543,7 +543,7 @@ local function new(type)
 	return self
 end
 
-local function new_from_uri(uri, protocols)
+local function new_from_uri(uri, protocols, headers)
 	local request = http_request.new_from_uri(uri)
 	local self = new("client")
 	self.request = request
@@ -553,6 +553,9 @@ local function new_from_uri(uri, protocols)
 	self.key = new_key()
 	self.request.headers:append("sec-websocket-key", self.key, true)
 	self.request.headers:append("sec-websocket-version", "13")
+	for name, value, _ in headers:each() do
+		self.request.headers:append(name, value)
+	end
 	if protocols then
 		--[[ The request MAY include a header field with the name
 		Sec-WebSocket-Protocol. If present, this value indicates one


### PR DESCRIPTION
Add custom headers into the websocket client connection by passing an http.headers object to the http.websocket.new_from_uri function and add the custom headers to the existing ones.

Issue : https://github.com/daurnimator/lua-http/issues/231